### PR TITLE
feat: close new game modal immediately and reset selected data after

### DIFF
--- a/src/app/my-game/page.tsx
+++ b/src/app/my-game/page.tsx
@@ -119,6 +119,8 @@ export default function LoadGameScreen() {
       return;
     }
 
+    // Immediately close the dialog so it's not visible during creation
+    setShowNewGameModal(false);
     setCreatingGame(true);
 
     axios
@@ -128,8 +130,9 @@ export default function LoadGameScreen() {
       })
       .then((response) => {
         console.log("Game created successfully:", response.data);
-        setShowNewGameModal(false);
+        // Navigate to the new game
         router.push(`/game/${response.data.id}`);
+        // Reset any selected data
         setSelectedCompany(null);
         setSelectedScenario(null);
       })


### PR DESCRIPTION
This pull request includes changes to the `LoadGameScreen` component in the `src/app/my-game/page.tsx` file to improve user experience during game creation. The most important changes include immediately closing the new game modal to prevent it from being visible during the game creation process and ensuring proper navigation and reset of selected data after a game is created.

Improvements to user experience:

* [`src/app/my-game/page.tsx`](diffhunk://#diff-062842abd44aecbb74e48fe51d0b176200b72682e4dbd6e81a316d3bb8e836c8R122-R123): Immediately close the new game modal so it's not visible during game creation.
* [`src/app/my-game/page.tsx`](diffhunk://#diff-062842abd44aecbb74e48fe51d0b176200b72682e4dbd6e81a316d3bb8e836c8L131-R135): Ensure proper navigation to the newly created game and reset any selected data.…game creation