### PR TITLE
Fix/creating game UI overflow my company

### DIFF
--- a/src/components/my-game/CompanySelector.tsx
+++ b/src/components/my-game/CompanySelector.tsx
@@ -299,7 +299,7 @@ export default function CompanySelector({ selectedCompany, onCompanySelect }: Co
       </DialogTrigger>
 
       {/* Dialog Content */}
-      <DialogContent className="sm:max-w-[650px] max-h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="sm:max-w-[650px] max-h-[85vh] overflow-y-auto flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />

--- a/src/components/my-game/ScenarioSelector.tsx
+++ b/src/components/my-game/ScenarioSelector.tsx
@@ -219,7 +219,7 @@ export default function ScenarioSelector({ selectedScenario, onScenarioSelect }:
       </DialogTrigger>
 
       {/* Dialog Content */}
-      <DialogContent className="sm:max-w-[650px] max-h-[85vh] overflow-hidden flex flex-col">
+      <DialogContent className="sm:max-w-[650px] max-h-[85vh] overflow-y-auto flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5" />
@@ -247,7 +247,7 @@ export default function ScenarioSelector({ selectedScenario, onScenarioSelect }:
           </TabsList>
 
           {/* My Scenarios Tab */}
-          <TabsContent value="my-scenarios" className="flex-1 overflow-hidden flex flex-col min-h-0">
+          <TabsContent value="my-scenarios" className="flex-1 overflow-y-auto flex flex-col min-h-0">
             {isLoadingScenarios ? (
               <div className="flex flex-col items-center justify-center h-full py-8 text-center">
                 <p className="text-lg">Loading your scenarios...</p>


### PR DESCRIPTION
This pull request includes changes to the `CompanySelector` and `ScenarioSelector` components to improve the user interface by modifying the overflow behavior of dialog content and tabs.

User Interface Improvements:

* [`src/components/my-game/CompanySelector.tsx`](diffhunk://#diff-d85e577b65bff312a705b377b2f62ed280ee641b5596634a593bf365fc760a1eL302-R302): Changed the `DialogContent` class to use `overflow-y-auto` instead of `overflow-hidden` to allow vertical scrolling.
* [`src/components/my-game/ScenarioSelector.tsx`](diffhunk://#diff-28b374785c77ea18c79dd4e9612d5e0825ab3ac5e4666e815d8aa3b6aff875faL222-R222): Changed the `DialogContent` class to use `overflow-y-auto` instead of `overflow-hidden` to allow vertical scrolling.
* [`src/components/my-game/ScenarioSelector.tsx`](diffhunk://#diff-28b374785c77ea18c79dd4e9612d5e0825ab3ac5e4666e815d8aa3b6aff875faL250-R250): Changed the `TabsContent` class for "my-scenarios" to use `overflow-y-auto` instead of `overflow-hidden` to allow vertical scrolling.